### PR TITLE
Adding a memory map package in the VHDL outputs so that the VHDL modules can use addresses as constants

### DIFF
--- a/src/addr_gen_wb.py
+++ b/src/addr_gen_wb.py
@@ -24,11 +24,13 @@ import zlib
 import argparse
 import wb_block as wb
 import include
+import logging as log
 
 # The module expressions accepts definitions of constants (function addval)
 # and evaluates the expressions (function exprval)
 import expressions as ex
 import yaml
+
 
 
 PARSER = argparse.ArgumentParser()
@@ -46,7 +48,12 @@ PARSER.add_argument(
 )
 PARSER.add_argument("--fusesoc_vlnv", help="FuseSoc VLNV tag", default="")
 PARSER.add_argument("--eprj", help="Generate the VEXTPROJ .eprj file", action="store_true")
+PARSER.add_argument("--verbose", help="Add verbosity to program output", action="store_true")
 ARGS = PARSER.parse_args()
+
+if ARGS.verbose:
+    log.basicConfig(level=log.DEBUG)
+    
 
 INFILENAME = ARGS.infile
 

--- a/src/wb_block.py
+++ b/src/wb_block.py
@@ -1582,7 +1582,7 @@ end if;
             self.add_templ("testdev_access",d_t,10);
         # If the outputs must be aggregated in a single record,
         # we will generate a type for that record instead of output ports
-        log.debug(self, self.name)
+        log.debug(self.name)
         # Generate the block version id constants
         d_c = 'constant c_'+self.name+'_ver_id : std_logic_vector(31 downto 0) := '
         d_c += 'x"' + format(self.ver_full, "08x") + '";\n'

--- a/src/wb_block.py
+++ b/src/wb_block.py
@@ -265,6 +265,12 @@ def blocks():
 def blackboxes():
     return GLB.blackboxes
 
+
+def vhdl_address_cst_str(name, addr):
+    res = f'constant {name}_addr : std_logic_vector(32 - 1 downto 0) := x"{addr:08x}";'    
+    return res
+    
+
 def get_reps(el):
     """ That function reads the number of repetitions of the block or register
         in different variants, or reads the information about its usage 
@@ -931,6 +937,12 @@ class WbReg(WbObject):
         parent.add_templ("register_access", d_t, 10)
         parent.add_templ("signals_idle", d_i, 8)
         parent.add_templ("trigger_bits_reset", d_tbr, 8)
+
+    def gen_vhdl_map(self, base, name):
+        res = ""
+        res += vhdl_address_cst_str(name=name+ self.name, addr=base+self.base)
+        res += " --" + self.desc + "\n"
+        return res
 
     def gen_amap_xml(self, reg_base, nvar = None):
         res = ""
@@ -1777,6 +1789,7 @@ end if;
             self.set_templ("ack_record","")
         # All template is filled, so we can now generate the files
         wb_vhdl_pkg_file = GLB.VHDL_PATH + "/" + self.name + "_pkg.vhd"
+        log.debug(self.areas)
         with open(wb_vhdl_pkg_file, "w") as f_o:
             f_o.write(TEMPL_PKG.format(**self.templ_dict))
             created_files["vhdl"].append(wb_vhdl_pkg_file)
@@ -1784,6 +1797,97 @@ end if;
         with open(wb_vhdl_file, "w") as f_o:
             f_o.write(templ_wb(self.N_MASTERS).format(**self.templ_dict))
             created_files["vhdl"].append(wb_vhdl_file)
+            
+        # TODO: make the map generation a parameter
+        
+        # map_const = '   constant c_{reg_name}_off : {address_t} := {reg_address};\n'
+        # address_const = ''.join([map_const for x in range(6)])
+        parameters_dict = {
+            'p_entity' : self.templ_dict['p_entity'],
+            'address_const' : ''
+                           }
+        
+        template = '''\
+--- This file has been automatically generated
+--- by the agwb (https://github.com/wzab/agwb).
+--- Please don't edit it manually, unless you really have to do it
+library ieee;
+
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library general_cores;
+use general_cores.wishbone_pkg.all;
+
+library work;
+use work.agwb_pkg.all;
+
+package {p_entity}_wb_map_pkg is
+{address_const}
+end {p_entity}_wb_map_pkg;
+'''
+
+        
+        parameters_dict['address_const'] = self.gen_vhdl_map(0, "")
+        wb_vhdl_wb_map_pkg_file = GLB.VHDL_PATH + "/" + self.name + "_wb_map_pkg.vhd"
+        with open(wb_vhdl_wb_map_pkg_file, "w") as f_o:
+            f_o.write(template.format(**parameters_dict))
+            created_files["vhdl"].append(wb_vhdl_wb_map_pkg_file)
+        
+    def gen_vhdl_map(self, base, mname):
+        """This function generates a VHDL register mapping so that register addresses are available as constants for the digital design itself
+        """
+        res = ""
+        
+        if mname != "":
+            mname += '_' # appending to module name
+        
+        self.areas.sort(key=WbArea.sort_adr)
+        for (
+            a_r
+        ) in self.areas:  # We assume that they are sorted by increasing base address
+            if a_r.obj is None:
+                area_name = "-- Registers"
+            else:
+                area_name = a_r.name
+            res += "\n"
+            res += (
+                "--" +
+                hex(base + a_r.adr)
+                + "-"
+                + hex(base + a_r.adr + a_r.total_size - 1)
+                + " "
+                + area_name
+                + "\n"
+            )
+            # Here we generate the detailed description of the area
+            if a_r.obj is None:
+                # Registers
+                res += (
+                    vhdl_address_cst_str(name=mname+'id', addr=base+a_r.adr)
+                    + " -- block ID register\n"
+                )
+                res += (
+                    vhdl_address_cst_str(name=mname+'ver', addr=base+a_r.adr+1)
+                    + " -- block VER register\n"
+                )
+                for reg in self.regs:
+                    res += reg.gen_vhdl_map(base + a_r.adr, mname)
+            else:
+                # Blocks or vectors of blocks
+                if (a_r.reps == 1) and (a_r.force_vec == False):
+                    # Single block
+                    res += a_r.obj.gen_vhdl_map(base + a_r.adr, mname + a_r.name)
+                else:
+                    # Vector of blocks
+                    for i in range(0, a_r.reps):
+                        res += a_r.obj.gen_vhdl_map(
+                            base + a_r.adr + i * a_r.obj.addr_size,
+                            mname + "." + a_r.name + "[" + str(i) + "]",
+                        )
+                    res += "\n"
+        return res
+        
 
     def amap_xml_hdr(self,ver_hash):
         res = '<module id="' + self.name


### PR DESCRIPTION
The idea is to be able to use the resolved addresses as constants inside the VHDL

Tested with a simple design (only blocks & subblocks), not sure yet if it works for blackboxes, etc

A nice to have upgrade would be to use the constants inside the generated crossbar wrappers instead of magic binary constants :
`  constant c_address : t_wishbone_address_array(4-1  downto 0) := (0=>"00000000000000000000000000110000",1=>"00000000000000000000000000100000",2=>"00000000000000000000000000011000",3=>"00000000000000000000000000000000");
`